### PR TITLE
[codex] Fix PostgreSQL 18 volume path

### DIFF
--- a/compose/postgres/files/compose.yaml
+++ b/compose/postgres/files/compose.yaml
@@ -23,9 +23,9 @@ services:
     <%- endif %>
     volumes:
       <%- if volume_mode == 'mount' %>
-      - << volume_mount_path >>:/var/lib/postgresql/data:rw
+      - << volume_mount_path >>:/var/lib/postgresql:rw
       <%- else %>
-      - << service_name >>-data:/var/lib/postgresql/data
+      - << service_name >>-data:/var/lib/postgresql
       <%- endif %>
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]

--- a/swarm/postgres/files/compose.yaml
+++ b/swarm/postgres/files/compose.yaml
@@ -24,9 +24,9 @@ services:
     <%- endif %>
     volumes:
       <%- if volume_mode == 'mount' %>
-      - << volume_mount_path >>:/var/lib/postgresql/data:rw
+      - << volume_mount_path >>:/var/lib/postgresql:rw
       <%- else %>
-      - << service_name >>-data:/var/lib/postgresql/data
+      - << service_name >>-data:/var/lib/postgresql
       <%- endif %>
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U << database_user >>"]


### PR DESCRIPTION
## Summary
- update Compose and Swarm PostgreSQL templates to mount persistent storage at /var/lib/postgresql
- avoid the PostgreSQL 18 startup failure caused by mounting directly at /var/lib/postgresql/data

Closes #180

## Validation
- git diff --check
- boilerplates compose validate postgres --semantic (blocked: installed boilerplates 0.1.2 cannot load this 0.2.0+ template library and reports template not found)
- boilerplates compose validate --path swarm/postgres --semantic (blocked: installed boilerplates 0.1.2 expects template.yaml/template.yml, but this library uses template.json)