### PR TITLE
Fix Grafana Docker image repository

### DIFF
--- a/compose/grafana/files/compose.yaml
+++ b/compose/grafana/files/compose.yaml
@@ -1,6 +1,6 @@
 services:
   << service_name >>:
-    image: docker.io/grafana/grafana-oss:13.0.1
+    image: docker.io/grafana/grafana:13.0.1
     restart: << restart_policy >>
     <%- if database_type == 'postgres' or authentik_enabled %>
     environment:

--- a/compose/grafana/template.json
+++ b/compose/grafana/template.json
@@ -15,7 +15,7 @@
     "draft": false,
     "version": {
       "name": "13.0.1",
-      "source_dep_name": "docker.io/grafana/grafana-oss",
+      "source_dep_name": "docker.io/grafana/grafana",
       "source_dep_version": "13.0.1"
     }
   },

--- a/renovate.json
+++ b/renovate.json
@@ -130,7 +130,7 @@
       ],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+(?:-security-\\d+)?)$",
       "matchPackageNames": [
-        "/^([^/]+\\/)*grafana\/grafana-oss(:.+)?$/"
+        "/^([^/]+\\/)*grafana\/grafana(:.+)?$/"
       ]
     },
     {


### PR DESCRIPTION
Closes #191

Updates the Grafana compose template and Renovate package matching from `grafana/grafana-oss` to `grafana/grafana`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Grafana Docker image from `grafana/grafana-oss` to `grafana/grafana` to use the correct repository. Updates the compose file, template metadata, and `renovate.json` match pattern so Renovate tracks future releases.

<sup>Written for commit df6d0849ed9b8c243a3b4b8bdf5ec1a693b8c6d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

