### PR TITLE
feat(swarm): add Traefik Swarm template

### DIFF
--- a/swarm/traefik/files/.env.secret.aws_credentials
+++ b/swarm/traefik/files/.env.secret.aws_credentials
@@ -1,0 +1,5 @@
+<%- if traefik_tls_certresolver == 'route53' %>
+[default]
+aws_access_key_id = << traefik_tls_acme_token >>
+aws_secret_access_key = << traefik_tls_acme_secret_key >>
+<%- endif %>

--- a/swarm/traefik/files/.env.secret.consumer_key
+++ b/swarm/traefik/files/.env.secret.consumer_key
@@ -1,0 +1,1 @@
+<%- if traefik_tls_acme_consumer_key %><< traefik_tls_acme_consumer_key >><%- endif %>

--- a/swarm/traefik/files/.env.secret.token
+++ b/swarm/traefik/files/.env.secret.token
@@ -1,1 +1,1 @@
-<%- if traefik_tls_acme_token %><< traefik_tls_acme_token >><%- endif %>
+<%- if traefik_tls_acme_token and traefik_tls_certresolver != 'route53' %><< traefik_tls_acme_token >><%- endif %>

--- a/swarm/traefik/files/.env.secret.token
+++ b/swarm/traefik/files/.env.secret.token
@@ -1,0 +1,1 @@
+<%- if traefik_tls_acme_token %><< traefik_tls_acme_token >><%- endif %>

--- a/swarm/traefik/files/.env.secret.token_key
+++ b/swarm/traefik/files/.env.secret.token_key
@@ -1,1 +1,1 @@
-<%- if traefik_tls_acme_secret_key %><< traefik_tls_acme_secret_key >><%- endif %>
+<%- if traefik_tls_acme_secret_key and traefik_tls_certresolver != 'route53' %><< traefik_tls_acme_secret_key >><%- endif %>

--- a/swarm/traefik/files/.env.secret.token_key
+++ b/swarm/traefik/files/.env.secret.token_key
@@ -1,0 +1,1 @@
+<%- if traefik_tls_acme_secret_key %><< traefik_tls_acme_secret_key >><%- endif %>

--- a/swarm/traefik/files/compose.yaml
+++ b/swarm/traefik/files/compose.yaml
@@ -86,8 +86,7 @@ services:
       - PORKBUN_API_KEY_FILE=/run/secrets/<< service_name >>_token
       - PORKBUN_SECRET_API_KEY_FILE=/run/secrets/<< service_name >>_token_key
       <%- elif traefik_tls_certresolver == 'route53' %>
-      - AWS_ACCESS_KEY_ID_FILE=/run/secrets/<< service_name >>_token
-      - AWS_SECRET_ACCESS_KEY_FILE=/run/secrets/<< service_name >>_token_key
+      - AWS_SHARED_CREDENTIALS_FILE=/run/secrets/<< service_name >>_aws_credentials
       - AWS_REGION=<< traefik_tls_acme_region >>
       <%- elif traefik_tls_certresolver == 'digitalocean' %>
       - DO_AUTH_TOKEN_FILE=/run/secrets/<< service_name >>_token
@@ -120,12 +119,16 @@ services:
       - << traefik_network >>
     <%- if traefik_tls_enabled %>
     secrets:
+      <%- if traefik_tls_certresolver == 'route53' %>
+      - << service_name >>_aws_credentials
+      <%- else %>
       - << service_name >>_token
-      <%- if traefik_tls_certresolver == 'azure' or traefik_tls_certresolver == 'godaddy' or traefik_tls_certresolver == 'ovh' or traefik_tls_certresolver == 'porkbun' or traefik_tls_certresolver == 'route53' %>
+      <%- if traefik_tls_certresolver == 'azure' or traefik_tls_certresolver == 'godaddy' or traefik_tls_certresolver == 'ovh' or traefik_tls_certresolver == 'porkbun' %>
       - << service_name >>_token_key
       <%- endif %>
       <%- if traefik_tls_certresolver == 'ovh' %>
       - << service_name >>_consumer_key
+      <%- endif %>
       <%- endif %>
     <%- endif %>
     deploy:
@@ -133,25 +136,31 @@ services:
       <%- if swarm_placement_mode == 'replicated' %>
       replicas: << swarm_replicas >>
       <%- endif %>
-      <%- if swarm_placement_host %>
       placement:
         constraints:
+          - node.role == manager
+          <%- if swarm_placement_host %>
           - node.hostname == << swarm_placement_host >>
-      <%- endif %>
+          <%- endif %>
       restart_policy:
         condition: any
 
 <%- if traefik_tls_enabled %>
 secrets:
+  <%- if traefik_tls_certresolver == 'route53' %>
+  << service_name >>_aws_credentials:
+    file: ./.env.secret.aws_credentials
+  <%- else %>
   << service_name >>_token:
     file: ./.env.secret.token
-  <%- if traefik_tls_certresolver == 'azure' or traefik_tls_certresolver == 'godaddy' or traefik_tls_certresolver == 'ovh' or traefik_tls_certresolver == 'porkbun' or traefik_tls_certresolver == 'route53' %>
+  <%- if traefik_tls_certresolver == 'azure' or traefik_tls_certresolver == 'godaddy' or traefik_tls_certresolver == 'ovh' or traefik_tls_certresolver == 'porkbun' %>
   << service_name >>_token_key:
     file: ./.env.secret.token_key
   <%- endif %>
   <%- if traefik_tls_certresolver == 'ovh' %>
   << service_name >>_consumer_key:
     file: ./.env.secret.consumer_key
+  <%- endif %>
   <%- endif %>
 <%- endif %>
 

--- a/swarm/traefik/files/compose.yaml
+++ b/swarm/traefik/files/compose.yaml
@@ -1,0 +1,180 @@
+---
+services:
+  << service_name >>:
+    image: docker.io/library/traefik:v3.6.15
+    command:
+      - "--global.checkNewVersion=false"
+      - "--global.sendAnonymousUsage=false"
+      - "--log.level=<< container_loglevel >>"
+      - "--ping=true"
+      - "--ping.entryPoint=ping"
+      <%- if accesslog_enabled %>
+      - "--accesslog=true"
+      <%- endif %>
+      <%- if dashboard_enabled %>
+      - "--api.dashboard=true"
+      - "--api.insecure=true"
+      <%- endif %>
+      <%- if prometheus_enabled %>
+      - "--metrics.prometheus=true"
+      - "--metrics.prometheus.entryPoint=metrics"
+      - "--metrics.prometheus.addRoutersLabels=true"
+      <%- endif %>
+      - "--entrypoints.ping.address=:8082"
+      <%- if prometheus_enabled %>
+      - "--entrypoints.metrics.address=:9090"
+      <%- endif %>
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.encodedCharacters.allowEncodedSlash=true"
+      <%- if traefik_tls_enabled and traefik_tls_redirect %>
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      <%- endif %>
+      <%- if traefik_tls_enabled %>
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.websecure.http.encodedCharacters.allowEncodedSlash=true"
+      - "--certificatesresolvers.<< traefik_tls_certresolver >>.acme.email=<< traefik_tls_acme_email >>"
+      - "--certificatesresolvers.<< traefik_tls_certresolver >>.acme.caServer=https://acme-v02.api.letsencrypt.org/directory"
+      - "--certificatesresolvers.<< traefik_tls_certresolver >>.acme.storage=/var/traefik/certs/acme.json"
+      - "--certificatesresolvers.<< traefik_tls_certresolver >>.acme.dnsChallenge.provider=<< traefik_tls_certresolver >>"
+      - "--certificatesresolvers.<< traefik_tls_certresolver >>.acme.dnsChallenge.resolvers=1.1.1.1:53,8.8.8.8:53"
+      - "--tls.options.default.minVersion=<< traefik_tls_min_version >>"
+      <%- endif %>
+      <%- if traefik_tls_secure_ciphers %>
+      - "--tls.options.default.cipherSuites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+      <%- endif %>
+      <%- if traefik_tls_skipverify %>
+      - "--serversTransport.insecureSkipVerify=true"
+      <%- endif %>
+      - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
+      - "--providers.swarm.exposedByDefault=false"
+      - "--providers.swarm.network=<< traefik_network >>"
+    ports:
+      - target: 80
+        published: << ports_http >>
+        protocol: tcp
+        mode: << ports_publish_mode >>
+      - target: 443
+        published: << ports_https >>
+        protocol: tcp
+        mode: << ports_publish_mode >>
+      <%- if dashboard_enabled %>
+      - target: 8080
+        published: << ports_dashboard >>
+        protocol: tcp
+        mode: << ports_publish_mode >>
+      <%- endif %>
+      <%- if prometheus_enabled %>
+      - target: 9090
+        published: << ports_metrics >>
+        protocol: tcp
+        mode: << ports_publish_mode >>
+      <%- endif %>
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      <%- if volume_mode == 'mount' %>
+      - << volume_mount_path >>:/var/traefik/certs:rw
+      <%- elif volume_mode == 'local' or volume_mode == 'nfs' %>
+      - << service_name >>_certs:/var/traefik/certs:rw
+      <%- endif %>
+    environment:
+      - TZ=<< container_timezone >>
+      <%- if traefik_tls_enabled %>
+      <%- if traefik_tls_certresolver == 'cloudflare' %>
+      - CF_DNS_API_TOKEN_FILE=/run/secrets/<< service_name >>_token
+      <%- elif traefik_tls_certresolver == 'porkbun' %>
+      - PORKBUN_API_KEY_FILE=/run/secrets/<< service_name >>_token
+      - PORKBUN_SECRET_API_KEY_FILE=/run/secrets/<< service_name >>_token_key
+      <%- elif traefik_tls_certresolver == 'route53' %>
+      - AWS_ACCESS_KEY_ID_FILE=/run/secrets/<< service_name >>_token
+      - AWS_SECRET_ACCESS_KEY_FILE=/run/secrets/<< service_name >>_token_key
+      - AWS_REGION=<< traefik_tls_acme_region >>
+      <%- elif traefik_tls_certresolver == 'digitalocean' %>
+      - DO_AUTH_TOKEN_FILE=/run/secrets/<< service_name >>_token
+      <%- elif traefik_tls_certresolver == 'godaddy' %>
+      - GODADDY_API_KEY_FILE=/run/secrets/<< service_name >>_token
+      - GODADDY_API_SECRET_FILE=/run/secrets/<< service_name >>_token_key
+      <%- elif traefik_tls_certresolver == 'azure' %>
+      - AZURE_CLIENT_ID_FILE=/run/secrets/<< service_name >>_token
+      - AZURE_CLIENT_SECRET_FILE=/run/secrets/<< service_name >>_token_key
+      - AZURE_TENANT_ID=<< traefik_tls_acme_tenant_id >>
+      - AZURE_SUBSCRIPTION_ID=<< traefik_tls_acme_subscription_id >>
+      - AZURE_RESOURCE_GROUP=<< traefik_tls_acme_resource_group >>
+      <%- elif traefik_tls_certresolver == 'namecheap' %>
+      - NAMECHEAP_API_KEY_FILE=/run/secrets/<< service_name >>_token
+      - NAMECHEAP_API_USER=<< traefik_tls_acme_username >>
+      <%- elif traefik_tls_certresolver == 'ovh' %>
+      - OVH_ENDPOINT=<< traefik_tls_acme_endpoint >>
+      - OVH_APPLICATION_KEY_FILE=/run/secrets/<< service_name >>_token
+      - OVH_APPLICATION_SECRET_FILE=/run/secrets/<< service_name >>_token_key
+      - OVH_CONSUMER_KEY_FILE=/run/secrets/<< service_name >>_consumer_key
+      <%- endif %>
+      <%- endif %>
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8082/ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - << traefik_network >>
+    <%- if traefik_tls_enabled %>
+    secrets:
+      - << service_name >>_token
+      <%- if traefik_tls_certresolver == 'azure' or traefik_tls_certresolver == 'godaddy' or traefik_tls_certresolver == 'ovh' or traefik_tls_certresolver == 'porkbun' or traefik_tls_certresolver == 'route53' %>
+      - << service_name >>_token_key
+      <%- endif %>
+      <%- if traefik_tls_certresolver == 'ovh' %>
+      - << service_name >>_consumer_key
+      <%- endif %>
+    <%- endif %>
+    deploy:
+      mode: << swarm_placement_mode >>
+      <%- if swarm_placement_mode == 'replicated' %>
+      replicas: << swarm_replicas >>
+      <%- endif %>
+      <%- if swarm_placement_host %>
+      placement:
+        constraints:
+          - node.hostname == << swarm_placement_host >>
+      <%- endif %>
+      restart_policy:
+        condition: any
+
+<%- if traefik_tls_enabled %>
+secrets:
+  << service_name >>_token:
+    file: ./.env.secret.token
+  <%- if traefik_tls_certresolver == 'azure' or traefik_tls_certresolver == 'godaddy' or traefik_tls_certresolver == 'ovh' or traefik_tls_certresolver == 'porkbun' or traefik_tls_certresolver == 'route53' %>
+  << service_name >>_token_key:
+    file: ./.env.secret.token_key
+  <%- endif %>
+  <%- if traefik_tls_certresolver == 'ovh' %>
+  << service_name >>_consumer_key:
+    file: ./.env.secret.consumer_key
+  <%- endif %>
+<%- endif %>
+
+networks:
+  << traefik_network >>:
+    <%- if traefik_network_external %>
+    external: true
+    <%- else %>
+    driver: overlay
+    attachable: true
+    name: << traefik_network >>
+    <%- endif %>
+
+<%- if volume_mode == 'local' %>
+volumes:
+  << service_name >>_certs:
+    driver: local
+<%- elif volume_mode == 'nfs' %>
+volumes:
+  << service_name >>_certs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=<< volume_nfs_server >>,nfsvers=4,<< volume_nfs_options >>
+      device: ":<< volume_nfs_path >>"
+<%- endif %>

--- a/swarm/traefik/template.json
+++ b/swarm/traefik/template.json
@@ -410,7 +410,7 @@
               "replicated"
             ]
           },
-          "description": "Swarm deployment mode. Use replicated with one replica when Traefik manages ACME certificates. Global mode can run one task per eligible node, but Traefik OSS cannot safely coordinate active-active ACME writes to a shared acme.json. See https://doc.traefik.io/traefik/https/acme/."
+          "description": "Swarm deployment mode. Traefik is constrained to manager nodes because the Swarm provider reads service state through the local Docker socket. Use replicated with one replica when Traefik manages ACME certificates. Global mode runs one task per eligible manager node, but Traefik OSS cannot safely coordinate active-active ACME writes to a shared acme.json. See https://doc.traefik.io/traefik/providers/swarm/ and https://doc.traefik.io/traefik/https/acme/."
         },
         {
           "name": "swarm_replicas",
@@ -440,7 +440,7 @@
           "config": {
             "placeholder": "swarm-node-1"
           },
-          "description": "Optional node hostname constraint."
+          "description": "Optional manager-node hostname constraint. The selected node must be a Swarm manager."
         }
       ]
     },

--- a/swarm/traefik/template.json
+++ b/swarm/traefik/template.json
@@ -1,0 +1,525 @@
+{
+  "slug": "traefik-swarm",
+  "kind": "swarm",
+  "metadata": {
+    "name": "Traefik",
+    "description": "Swarm-only Traefik reverse proxy and load balancer with Docker Swarm service discovery, optional Let's Encrypt DNS challenge TLS, dashboard, and metrics support.",
+    "tags": [
+      "reverse-proxy",
+      "traefik"
+    ],
+    "icon": {
+      "provider": "selfhst",
+      "id": "traefik"
+    },
+    "draft": false,
+    "version": {
+      "name": "v3.6.15",
+      "source_dep_name": "docker.io/library/traefik",
+      "source_dep_version": "v3.6.15"
+    }
+  },
+  "variables": [
+    {
+      "title": "General",
+      "name": "general",
+      "items": [
+        {
+          "name": "service_name",
+          "title": "Service Name",
+          "type": "str",
+          "default": "traefik",
+          "required": false,
+          "config": {
+            "placeholder": "traefik"
+          },
+          "description": "Name of the Swarm service and generated resources."
+        },
+        {
+          "name": "container_timezone",
+          "title": "Container Timezone",
+          "type": "str",
+          "default": "UTC",
+          "required": true,
+          "config": {
+            "placeholder": "UTC"
+          },
+          "description": "Timezone used inside the container."
+        },
+        {
+          "name": "container_loglevel",
+          "title": "Log Level",
+          "type": "enum",
+          "default": "info",
+          "required": false,
+          "config": {
+            "options": [
+              "debug",
+              "info",
+              "warn",
+              "error"
+            ]
+          },
+          "description": "Traefik log level."
+        }
+      ]
+    },
+    {
+      "title": "Ports",
+      "name": "ports",
+      "items": [
+        {
+          "name": "ports_http",
+          "title": "HTTP Port",
+          "type": "int",
+          "default": 80,
+          "required": true,
+          "config": {
+            "placeholder": "80"
+          },
+          "description": "Published port for the web entrypoint."
+        },
+        {
+          "name": "ports_https",
+          "title": "HTTPS Port",
+          "type": "int",
+          "default": 443,
+          "required": true,
+          "config": {
+            "placeholder": "443"
+          },
+          "description": "Published port for the websecure entrypoint."
+        },
+        {
+          "name": "ports_dashboard",
+          "title": "Dashboard Port",
+          "type": "int",
+          "default": 8080,
+          "required": true,
+          "needs": [
+            "dashboard_enabled=true"
+          ],
+          "config": {
+            "placeholder": "8080"
+          },
+          "description": "Published port for the insecure dashboard/API."
+        },
+        {
+          "name": "ports_metrics",
+          "title": "Metrics Port",
+          "type": "int",
+          "default": 9090,
+          "required": true,
+          "needs": [
+            "prometheus_enabled=true"
+          ],
+          "config": {
+            "placeholder": "9090"
+          },
+          "description": "Published port for Prometheus metrics."
+        },
+        {
+          "name": "ports_publish_mode",
+          "title": "Publish Mode",
+          "type": "enum",
+          "default": "host",
+          "required": true,
+          "config": {
+            "options": [
+              "host",
+              "ingress"
+            ]
+          },
+          "description": "Swarm port publishing mode. Host mode is recommended for edge proxies."
+        }
+      ]
+    },
+    {
+      "title": "Traefik",
+      "name": "traefik",
+      "items": [
+        {
+          "name": "traefik_network",
+          "title": "Network",
+          "type": "str",
+          "default": "traefik",
+          "required": true,
+          "config": {
+            "placeholder": "traefik"
+          },
+          "description": "Overlay network Traefik uses to reach routed Swarm services."
+        },
+        {
+          "name": "traefik_network_external",
+          "title": "External Network",
+          "type": "bool",
+          "default": false,
+          "required": false,
+          "description": "Use an existing external overlay network."
+        },
+        {
+          "name": "accesslog_enabled",
+          "title": "Access Log",
+          "type": "bool",
+          "default": false,
+          "required": false,
+          "description": "Enable Traefik access logs."
+        },
+        {
+          "name": "dashboard_enabled",
+          "title": "Dashboard",
+          "type": "bool",
+          "default": false,
+          "required": false,
+          "description": "Enable the insecure Traefik dashboard/API. Do not expose this in production."
+        },
+        {
+          "name": "prometheus_enabled",
+          "title": "Prometheus",
+          "type": "bool",
+          "default": false,
+          "required": false,
+          "description": "Enable Prometheus metrics."
+        }
+      ]
+    },
+    {
+      "title": "Traefik TLS",
+      "name": "traefik-tls",
+      "toggle": "traefik_tls_enabled",
+      "items": [
+        {
+          "name": "traefik_tls_enabled",
+          "title": "TLS",
+          "type": "bool",
+          "default": false,
+          "required": false,
+          "description": "Enable HTTPS/TLS with ACME DNS challenge."
+        },
+        {
+          "name": "traefik_tls_certresolver",
+          "title": "DNS Provider",
+          "type": "enum",
+          "default": "cloudflare",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true"
+          ],
+          "config": {
+            "options": [
+              "cloudflare",
+              "porkbun",
+              "godaddy",
+              "digitalocean",
+              "route53",
+              "azure",
+              "namecheap",
+              "ovh"
+            ]
+          },
+          "description": "ACME DNS challenge provider."
+        },
+        {
+          "name": "traefik_tls_acme_email",
+          "title": "ACME Email",
+          "type": "str",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true"
+          ],
+          "config": {
+            "placeholder": "admin@example.com"
+          },
+          "description": "Email address used for ACME registration."
+        },
+        {
+          "name": "traefik_tls_acme_token",
+          "title": "API Token / ID",
+          "type": "secret",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true",
+            "traefik_tls_certresolver=azure,cloudflare,digitalocean,godaddy,namecheap,ovh,porkbun,route53"
+          ],
+          "description": "DNS provider API token or access/client ID. Stored as a Swarm secret."
+        },
+        {
+          "name": "traefik_tls_acme_secret_key",
+          "title": "Secret Key",
+          "type": "secret",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true",
+            "traefik_tls_certresolver=azure,godaddy,ovh,porkbun,route53"
+          ],
+          "description": "DNS provider secret key. Stored as a Swarm secret."
+        },
+        {
+          "name": "traefik_tls_acme_consumer_key",
+          "title": "Consumer Key",
+          "type": "secret",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true",
+            "traefik_tls_certresolver=ovh"
+          ],
+          "description": "OVH consumer key. Stored as a Swarm secret."
+        },
+        {
+          "name": "traefik_tls_acme_username",
+          "title": "Username",
+          "type": "str",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true",
+            "traefik_tls_certresolver=namecheap"
+          ],
+          "config": {
+            "placeholder": "namecheap-user"
+          },
+          "description": "Namecheap API username."
+        },
+        {
+          "name": "traefik_tls_acme_region",
+          "title": "AWS Region",
+          "type": "str",
+          "default": "us-east-1",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true",
+            "traefik_tls_certresolver=route53"
+          ],
+          "config": {
+            "placeholder": "us-east-1"
+          },
+          "description": "AWS region for Route53."
+        },
+        {
+          "name": "traefik_tls_acme_endpoint",
+          "title": "OVH Endpoint",
+          "type": "str",
+          "default": "ovh-eu",
+          "required": false,
+          "needs": [
+            "traefik_tls_enabled=true",
+            "traefik_tls_certresolver=ovh"
+          ],
+          "config": {
+            "placeholder": "ovh-eu"
+          },
+          "description": "OVH API endpoint."
+        },
+        {
+          "name": "traefik_tls_acme_tenant_id",
+          "title": "Azure Tenant ID",
+          "type": "str",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true",
+            "traefik_tls_certresolver=azure"
+          ],
+          "description": "Azure tenant ID."
+        },
+        {
+          "name": "traefik_tls_acme_subscription_id",
+          "title": "Azure Subscription ID",
+          "type": "str",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true",
+            "traefik_tls_certresolver=azure"
+          ],
+          "description": "Azure subscription ID."
+        },
+        {
+          "name": "traefik_tls_acme_resource_group",
+          "title": "Azure Resource Group",
+          "type": "str",
+          "required": true,
+          "needs": [
+            "traefik_tls_enabled=true",
+            "traefik_tls_certresolver=azure"
+          ],
+          "description": "Azure DNS resource group."
+        },
+        {
+          "name": "traefik_tls_redirect",
+          "title": "HTTP Redirect",
+          "type": "bool",
+          "default": true,
+          "required": false,
+          "needs": [
+            "traefik_tls_enabled=true"
+          ],
+          "description": "Redirect all HTTP traffic to HTTPS."
+        },
+        {
+          "name": "traefik_tls_min_version",
+          "title": "Minimum TLS Version",
+          "type": "enum",
+          "default": "VersionTLS12",
+          "required": false,
+          "needs": [
+            "traefik_tls_enabled=true"
+          ],
+          "config": {
+            "options": [
+              "VersionTLS12",
+              "VersionTLS13"
+            ]
+          },
+          "description": "Minimum TLS version."
+        },
+        {
+          "name": "traefik_tls_secure_ciphers",
+          "title": "Strict Ciphers",
+          "type": "bool",
+          "default": false,
+          "required": false,
+          "needs": [
+            "traefik_tls_enabled=true"
+          ],
+          "description": "Enable a strict modern cipher suite list."
+        },
+        {
+          "name": "traefik_tls_skipverify",
+          "title": "Skip Backend Verify",
+          "type": "bool",
+          "default": false,
+          "required": false,
+          "needs": [
+            "traefik_tls_enabled=true"
+          ],
+          "description": "Skip TLS verification for backend servers."
+        }
+      ]
+    },
+    {
+      "title": "Docker Swarm",
+      "name": "swarm",
+      "items": [
+        {
+          "name": "swarm_placement_mode",
+          "title": "Placement Mode",
+          "type": "enum",
+          "default": "global",
+          "required": true,
+          "config": {
+            "options": [
+              "global",
+              "replicated"
+            ]
+          },
+          "description": "Swarm deployment mode. Global is useful with host-published edge ports."
+        },
+        {
+          "name": "swarm_replicas",
+          "title": "Replicas",
+          "type": "int",
+          "default": 1,
+          "required": false,
+          "needs": [
+            "swarm_placement_mode=replicated"
+          ],
+          "config": {
+            "slider": true,
+            "min": 1,
+            "max": 10,
+            "step": 1,
+            "placeholder": "1",
+            "unit": "replicas"
+          },
+          "description": "Number of replicas when placement mode is replicated."
+        },
+        {
+          "name": "swarm_placement_host",
+          "title": "Placement Host",
+          "type": "str",
+          "default": "",
+          "required": false,
+          "config": {
+            "placeholder": "swarm-node-1"
+          },
+          "description": "Optional node hostname constraint."
+        }
+      ]
+    },
+    {
+      "title": "Volume",
+      "name": "volume",
+      "items": [
+        {
+          "name": "volume_mode",
+          "title": "Volume Mode",
+          "type": "enum",
+          "default": "local",
+          "required": true,
+          "config": {
+            "options": [
+              "local",
+              "mount",
+              "nfs"
+            ]
+          },
+          "description": "Storage mode for ACME certificate data. Use shared storage when running more than one Traefik task."
+        },
+        {
+          "name": "volume_mount_path",
+          "title": "Bind Mount Path",
+          "type": "str",
+          "default": "/data/traefik/certs",
+          "required": true,
+          "needs": [
+            "volume_mode=mount"
+          ],
+          "config": {
+            "placeholder": "/data/traefik/certs"
+          },
+          "description": "Host path used for certificate storage."
+        },
+        {
+          "name": "volume_nfs_server",
+          "title": "NFS Server",
+          "type": "str",
+          "default": "NFS_SERVER",
+          "required": true,
+          "needs": [
+            "volume_mode=nfs"
+          ],
+          "config": {
+            "placeholder": "NFS_SERVER"
+          },
+          "description": "Hostname or IP address of the NFS server."
+        },
+        {
+          "name": "volume_nfs_path",
+          "title": "NFS Path",
+          "type": "str",
+          "default": "/export/traefik/certs",
+          "required": true,
+          "needs": [
+            "volume_mode=nfs"
+          ],
+          "config": {
+            "placeholder": "/export/traefik/certs"
+          },
+          "description": "Export path on the NFS server."
+        },
+        {
+          "name": "volume_nfs_options",
+          "title": "NFS Options",
+          "type": "str",
+          "default": "rw,nolock,soft",
+          "required": true,
+          "needs": [
+            "volume_mode=nfs"
+          ],
+          "config": {
+            "placeholder": "rw,nolock,soft"
+          },
+          "description": "Mount options for the NFS volume."
+        }
+      ]
+    }
+  ]
+}

--- a/swarm/traefik/template.json
+++ b/swarm/traefik/template.json
@@ -3,7 +3,7 @@
   "kind": "swarm",
   "metadata": {
     "name": "Traefik",
-    "description": "Swarm-only Traefik reverse proxy and load balancer with Docker Swarm service discovery, optional Let's Encrypt DNS challenge TLS, dashboard, and metrics support.",
+    "description": "Swarm-only Traefik reverse proxy and load balancer with Docker Swarm service discovery, optional Let's Encrypt DNS challenge TLS, dashboard, and metrics support. For Traefik-managed ACME certificates, run a single replica; Traefik OSS ACME storage is not safe for active-active writes from multiple instances. References: Traefik Swarm provider https://doc.traefik.io/traefik/providers/swarm/ and Traefik ACME storage notes https://doc.traefik.io/traefik/https/acme/.",
     "tags": [
       "reverse-proxy",
       "traefik"
@@ -402,7 +402,7 @@
           "name": "swarm_placement_mode",
           "title": "Placement Mode",
           "type": "enum",
-          "default": "global",
+          "default": "replicated",
           "required": true,
           "config": {
             "options": [
@@ -410,7 +410,7 @@
               "replicated"
             ]
           },
-          "description": "Swarm deployment mode. Global is useful with host-published edge ports."
+          "description": "Swarm deployment mode. Use replicated with one replica when Traefik manages ACME certificates. Global mode can run one task per eligible node, but Traefik OSS cannot safely coordinate active-active ACME writes to a shared acme.json. See https://doc.traefik.io/traefik/https/acme/."
         },
         {
           "name": "swarm_replicas",
@@ -429,7 +429,7 @@
             "placeholder": "1",
             "unit": "replicas"
           },
-          "description": "Number of replicas when placement mode is replicated."
+          "description": "Number of replicas when placement mode is replicated. Keep this at 1 when Traefik manages ACME certificates; use multiple replicas only with external/static certificate management."
         },
         {
           "name": "swarm_placement_host",
@@ -461,7 +461,7 @@
               "nfs"
             ]
           },
-          "description": "Storage mode for ACME certificate data. Use shared storage when running more than one Traefik task."
+          "description": "Storage mode for ACME certificate data. Shared storage allows file access from multiple nodes, but it does not make Traefik-managed ACME safe with multiple active Traefik writers. Use one Traefik replica for ACME, or use external/static certificate management for multi-replica Traefik. See https://doc.traefik.io/traefik/https/acme/."
         },
         {
           "name": "volume_mount_path",


### PR DESCRIPTION
## Summary
- add a dedicated Swarm-only Traefik template (`traefik-swarm`)
- port old Traefik Swarm provider/deploy/secrets/network logic from the legacy template
- document Traefik OSS ACME single-writer guidance and link upstream docs

## Validation
- `boilerplates swarm validate --path swarm/traefik --semantic --docker --docker-test-all -v`
- `boilerplates swarm validate --semantic`

Closes #193

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Swarm-only Traefik template with service discovery, optional ACME DNS TLS, dashboard, and Prometheus. Constrains the service to manager nodes and uses AWS shared-credentials for Route53 ACME via a Swarm secret; implements the template requested in issue #193 and documents ACME single-writer guidance.

- **New Features**
  - New `swarm/traefik` template using `docker.io/library/traefik:v3.6.15`.
  - ACME DNS challenge TLS with Cloudflare, Porkbun, GoDaddy, DigitalOcean, Route53 (AWS shared credentials secret), Azure, Namecheap, and OVH.
  - Toggles: access log, dashboard, Prometheus, HTTP→HTTPS redirect, min TLS version, strict ciphers, and backend skip-verify.
  - Configurable overlay network (external or managed), port publish mode (`host` or `ingress`), cert storage via local volume, bind mount, or NFS; placement constrained to manager nodes with optional host constraint.

- **Migration**
  - If Traefik manages ACME, run a single replica; use external/static certs if running multiple replicas.
  - Provide required DNS provider secrets and ensure the Traefik overlay network exists for routed services.

<sup>Written for commit dc8e4bc93594dbdc9d8491efdfb207c2b8f5dc60. Summary will update on new commits. <a href="https://cubic.dev/pr/ChristianLempa/boilerplates-library/pull/194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

