### PR TITLE
Fix Technitium DoH behind Traefik

### DIFF
--- a/compose/technitium/files/compose.yaml
+++ b/compose/technitium/files/compose.yaml
@@ -22,6 +22,9 @@ services:
       <%- if dns_server_enable_blocking %>
       - DNS_SERVER_ENABLE_BLOCKING=true
       <%- endif %>
+      <%- if dns_server_optional_protocol_dns_over_http %>
+      - DNS_SERVER_OPTIONAL_PROTOCOL_DNS_OVER_HTTP=true
+      <%- endif %>
     <%- if network_mode == 'host' %>
     network_mode: host
     <%- elif network_mode == 'bridge' or network_mode == 'macvlan' or traefik_enabled %>
@@ -40,6 +43,10 @@ services:
     ports:
       <%- if not traefik_enabled %>
       - "<< ports_web_http >>:5380/tcp"
+      - "<< ports_dns_over_https >>:443/tcp"
+      <%- if dns_server_optional_protocol_dns_over_http %>
+      - "<< ports_dns_over_http >>:80/tcp"
+      <%- endif %>
       <%- endif %>
       - "<< ports_dns >>:53/tcp"
       - "<< ports_dns >>:53/udp"
@@ -70,6 +77,15 @@ services:
       - traefik.http.routers.<< service_name >>-https.entrypoints=<< traefik_tls_entrypoint >>
       - traefik.http.routers.<< service_name >>-https.tls=true
       - traefik.http.routers.<< service_name >>-https.tls.certresolver=<< traefik_tls_certresolver >>
+      <%- if dns_server_optional_protocol_dns_over_http %>
+      - traefik.http.services.<< service_name >>-doh.loadBalancer.server.port=80
+      - traefik.http.routers.<< service_name >>-doh.service=<< service_name >>-doh
+      - traefik.http.routers.<< service_name >>-doh.rule=Host(`<< traefik_host >>.<< traefik_domain >>`) && Path(`/dns-query`)
+      - traefik.http.routers.<< service_name >>-doh.entrypoints=<< traefik_tls_entrypoint >>
+      - traefik.http.routers.<< service_name >>-doh.tls=true
+      - traefik.http.routers.<< service_name >>-doh.tls.certresolver=<< traefik_tls_certresolver >>
+      - traefik.http.routers.<< service_name >>-doh.priority=100
+      <%- endif %>
       <%- endif %>
     <%- endif %>
 <%- if network_mode == 'bridge' or network_mode == 'macvlan' or traefik_enabled %>

--- a/compose/technitium/template.json
+++ b/compose/technitium/template.json
@@ -158,6 +158,14 @@
           "description": "Enable Technitium block list functionality. Block lists can be managed in the web console."
         },
         {
+          "name": "dns_server_optional_protocol_dns_over_http",
+          "type": "bool",
+          "title": "Enable DNS-over-HTTP",
+          "required": false,
+          "default": false,
+          "description": "Enable Technitium's DNS-over-HTTP listener on port 80. This is required when running behind a TLS-terminating reverse proxy like Traefik and you want DNS-over-HTTPS on /dns-query."
+        },
+        {
           "name": "dns_server_log_using_local_time",
           "type": "bool",
           "title": "Use Local Time For Logs",
@@ -181,6 +189,31 @@
             "placeholder": "5380"
           },
           "description": "Host port exposed for the Technitium web console when Traefik is disabled."
+        },
+        {
+          "name": "ports_dns_over_http",
+          "type": "int",
+          "title": "DNS-over-HTTP Port",
+          "required": false,
+          "default": 80,
+          "config": {
+            "placeholder": "80"
+          },
+          "description": "Host port exposed for Technitium DNS-over-HTTP when Traefik is disabled. Behind Traefik, /dns-query is routed to container port 80 instead.",
+          "needs": [
+            "dns_server_optional_protocol_dns_over_http=true"
+          ]
+        },
+        {
+          "name": "ports_dns_over_https",
+          "type": "int",
+          "title": "DNS-over-HTTPS Port",
+          "required": false,
+          "default": 443,
+          "config": {
+            "placeholder": "443"
+          },
+          "description": "Host port exposed for native Technitium DNS-over-HTTPS when Traefik is disabled."
         },
         {
           "name": "ports_dns",


### PR DESCRIPTION
## Summary

- add optional Technitium DNS-over-HTTP toggle
- expose DNS-over-HTTP/HTTPS ports when Traefik is disabled and DoH is enabled
- add separate Traefik `/dns-query` router/service to container port `80` when TLS + DoH are enabled

Closes #197.

## Validation

- `python3 -m json.tool compose/technitium/template.json`
- `boilerplates compose validate technitium --path compose/technitium --verbose --docker`
- `boilerplates compose validate technitium --path compose/technitium --docker --docker-test-all`
- rendered default config and validated with `docker compose config -q`
- rendered DoH without Traefik and validated with `docker compose config -q`
- rendered Traefik TLS without DoH and validated with `docker compose config -q`
- rendered Traefik TLS + DoH and compared against `srv-test-1.home.clcreative.de:~/technitium/compose.yaml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Technitium DoH behind Traefik by adding an opt-in DNS-over-HTTP listener and a dedicated Traefik router/service that maps `/dns-query` to container port 80 with TLS (fixes #197). Also exposes DoH ports when Traefik is disabled.

- **Migration**
  - With Traefik + TLS: enable `dns_server_optional_protocol_dns_over_http` and use `https://<domain>/dns-query`.
  - Without Traefik: set `ports_dns_over_http` and/or `ports_dns_over_https` if you need host exposure.

<sup>Written for commit 46dd07c48b825646fca0fd82291a82a664b694fe. Summary will update on new commits. <a href="https://cubic.dev/pr/ChristianLempa/boilerplates-library/pull/198?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

